### PR TITLE
Fix missing argparse import

### DIFF
--- a/scripts/dart_bulk_downloader.py
+++ b/scripts/dart_bulk_downloader.py
@@ -13,6 +13,8 @@ import xml.etree.ElementTree as ET
 import aiohttp
 import pandas as pd
 from dotenv import load_dotenv
+import argparse
+import os
 
 # Load API key from .env at project root
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")


### PR DESCRIPTION
## Summary
- import argparse and os for script runtime

## Testing
- `python scripts/dart_bulk_downloader.py --sample 1 --start-year 2022 --end-year 2022 --workers 1 --output temp.xlsx` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_684835168180832fac233391dc592c0a