### PR TITLE
Fix check for empty DataFrame in team downloader

### DIFF
--- a/scripts/team_dart_downloader_fix.py
+++ b/scripts/team_dart_downloader_fix.py
@@ -56,7 +56,7 @@ async def download_team_data(api_key: str, team_num: int, corp_codes: List[str],
 
     statements = await fetch_bulk_statements(api_key, corp_codes, years, workers)
 
-    if not statements:
+    if statements.empty:
         print(f"❌ 팀 {team_num}: 수집된 데이터가 없어 파일을 저장하지 않습니다.")
         return
 


### PR DESCRIPTION
## Summary
- fix wrong boolean check when validating `fetch_bulk_statements` result

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848bd5ee220832f91c4429f93b4ac0d