### PR TITLE
Add DART batch downloader script

### DIFF
--- a/scripts/dart_bulk_downloader.py
+++ b/scripts/dart_bulk_downloader.py
@@ -211,9 +211,10 @@ async def fetch_bulk_statements(
     years: Iterable[int],
     workers: int = 5,
     include_corp_names: bool = True,
+    max_calls_per_minute: int = 600,
 ) -> pd.DataFrame:
     """Download statements for multiple companies in parallel."""
-    rate_limiter = RateLimiter(600, 60.0)  # 분당 600회로 안전하게 제한 (10,000회 제한 대응)
+    rate_limiter = RateLimiter(max_calls_per_minute, 60.0)
     results: List[pd.DataFrame] = []
     sem = asyncio.Semaphore(workers)
     


### PR DESCRIPTION
## Summary
- support per-minute rate limit configuration in `fetch_bulk_statements`
- add `dart_2015_2023_batch_downloader.py` for downloading 2015-2023 data in batches

## Testing
- `python scripts/dart_2015_2023_batch_downloader.py --start 1 --end 1 --workers 1` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_684cb4dc0658832fb3b4a23544b46ee0