### PR TITLE
Add corp code caching and refresh option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ python -m src.dart_bulk_downloader
 python scripts/fetch_financial_statements.py
 ```
 
+기존 진행 상황을 무시하고 처음부터 다시 받고 싶다면 `--reset` 옵션을 사용할 수 있습니다.
+
+```bash
+python scripts/fetch_financial_statements.py --reset
+```
+
+기업 코드 목록은 첫 실행 시 `data/corp_codes_cache.pkl`에 저장되며,
+필요할 경우 `--refresh-corp-codes` 옵션으로 새로 다운로드할 수 있습니다.
+
+```bash
+python scripts/fetch_financial_statements.py --refresh-corp-codes
+```
+
 실행하면 연결재무제표와 개별재무제표의 재무상태표·손익계산서가
 `data/raw/` 디렉터리에 각각 CSV 파일로 저장됩니다. 진행 상황은
 `tqdm` 프로그레스 바로 표시되며, 중간에 실행을 중단해도


### PR DESCRIPTION
## Summary
- support caching of corp codes when downloading financial statements
- add `--refresh-corp-codes` CLI flag for forcing a re-download
- document the cache in README

## Testing
- `python -m py_compile scripts/fetch_financial_statements.py`
- `python -m py_compile scripts/dart_bulk_downloader.py`

------
https://chatgpt.com/codex/tasks/task_e_684fe81aebe4832f83a3bb0f91ad9fa0