### PR TITLE
Fix pandas XML parsing without lxml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ aiohttp
 openpyxl
 pykrx
 tqdm
+python-dotenv

--- a/src/dart_bulk_downloader.py
+++ b/src/dart_bulk_downloader.py
@@ -53,7 +53,10 @@ async def fetch_corp_codes(api_key: str) -> pd.DataFrame:
 
     with zipfile.ZipFile(io.BytesIO(data)) as zf:
         xml_data = zf.read("CORPCODE.xml").decode("utf-8")
-    root = pd.read_xml(xml_data)
+    # ``read_xml`` expects a file-like object when parsing a string literal.
+    # Using the built-in ``etree`` parser avoids the optional ``lxml``
+    # dependency, which may not be available on all platforms.
+    root = pd.read_xml(io.StringIO(xml_data), parser="etree")
     return root
 
 


### PR DESCRIPTION
## Summary
- update parsing of DART corp code XML to use `etree`
- list `python-dotenv` in requirements

## Testing
- `python -m py_compile src/dart_bulk_downloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68500bd97054832f81d89faad9a598d5